### PR TITLE
Adding a Note for Compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ From your app root folder, verify that the Cordova Core and Push plugin were ins
 cordova plugin list
 ```
 
+>Note: Existing 3rd party push notification plugins (e.g., phonegap) may interfere with ibm-mfp-push. Be sure to remove these plugins to ensure proper funcitonality.
+
 ## Configuration
 
 ### Configuring Your iOS Development Environment


### PR DESCRIPTION
The CORD team recently worked with a customer to solve an issue that was caused by interference from a phonegap plugin installed in the same project. Once removed, the Bluemix cordova plugin started working properly. Figured this note was appropriate.
